### PR TITLE
File contents -> buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ var inlineSource = require('inline-source').sync;
 
 var inline = function(options) {
   return function(files, metalsmith, done) {
-     _.forEach(files, function(file, path, files) {
-      files[path].contents = inlineSource(files[path].contents.toString(), options);
+    _.forEach(files, function(file, path, files) {
+      files[path].contents = new Buffer(inlineSource(files[path].contents.toString(), options)), 'utf8';
     });
 
     done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-inline-source",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "A metalsmith plugin tied with inline-source to inline static assets, like SVG, JS and CSS",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-inline-source",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "description": "A metalsmith plugin tied with inline-source to inline static assets, like SVG, JS and CSS",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Instead of leaving file.contents as a `string`, convert it back into a `Buffer` so as to prevent errors with `gulpsmith`. This error is similar to what was seen in [`metalsmith-feeds`](https://github.com/hurrymaplelad/metalsmith-feed/issues/1).