### PR TITLE
Filter files to only process HTML content, and remove Lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _ = require('lodash');
 var inlineSource = require('inline-source').sync;
 
 /*
+ * Filter files to find HTML files.
  * Iterate through each file name and grab
  * the contents of each file and replace
  * with an inlined version.
@@ -11,9 +11,18 @@ var inlineSource = require('inline-source').sync;
 
 var inline = function(options) {
   return function(files, metalsmith, done) {
-     _.forEach(files, function(file, path, files) {
-      files[path].contents = inlineSource(files[path].contents.toString(), options);
-    });
+      var htmlFiles = Object.keys(files).filter(function(file) {
+        // Make sure the filename ends in either htm or html
+        var checkIfHtml = /[.](?:html?)$/.test(file);
+
+        if (checkIfHtml) {
+          return file;
+        }
+      });
+
+      htmlFiles.map(function(path) {
+        files[path].contents = inlineSource(files[path].contents.toString(), options);
+      });
 
     done();
   };

--- a/index.js
+++ b/index.js
@@ -11,18 +11,18 @@ var inlineSource = require('inline-source').sync;
 
 var inline = function(options) {
   return function(files, metalsmith, done) {
-      var htmlFiles = Object.keys(files).filter(function(file) {
-        // Make sure the filename ends in either htm or html
-        var checkIfHtml = /[.](?:html?)$/.test(file);
+    var htmlFiles = Object.keys(files).filter(function(file) {
+      // Make sure the filename ends in either htm or html
+      var checkIfHtml = /[.](?:html?)$/.test(file);
 
-        if (checkIfHtml) {
-          return file;
-        }
-      });
+      if (checkIfHtml) {
+        return file;
+      }
+    });
 
-      htmlFiles.map(function(path) {
-        files[path].contents = new Buffer(inlineSource(files[path].contents.toString(), options)), 'utf8';
-      });
+    htmlFiles.map(function(path) {
+      files[path].contents = new Buffer(inlineSource(files[path].contents.toString(), options)), 'utf8';
+    });
     done();
   };
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/alexnewmannn/metalsmith-inline-source#readme",
   "dependencies": {
-    "inline-source": "^4.2.2",
+    "inline-source": "^4.2.2"
   },
   "devDependencies": {
     "metalsmith": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/alexnewmannn/metalsmith-inline-source#readme",
   "dependencies": {
     "inline-source": "^4.2.2",
-    "lodash": "^3.0.0||^4.0.0"
   },
   "devDependencies": {
     "metalsmith": "^2.1.0"


### PR DESCRIPTION
Hi @alexnewmannn,
Thanks for your work on this. Hope you don't mind this PR.

I was encountering some issues with the plugin trying to run all files through the inliner, including images and other binaries. This was causing an error with `inline-source`.

I added a step to filter the files that the Metalsmith object passes, to only process HTML files.

This also closes #1 as it uses the JS native `map()` function to iterate over the files.